### PR TITLE
Stabilize Kafka 0.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Metrics can be filtered based on the metric name and the metric dimensions (min,
 ```bash
 
     # declare the reporter if new producer/consumer is used
-    metric.reporters=com.airbnb.kafka.StatsdMetricsReporter
+    metric.reporters=com.airbnb.kafka.NewStatsdMetricsReporter
 
     # declare the reporter if old producer/consumer is used
     kafka.metrics.reporters=com.airbnb.kafka.KafkaStatsdMetricsReporter

--- a/README.md
+++ b/README.md
@@ -17,13 +17,18 @@ This project provides a simple integration between Kafka and a StatsD reporter f
 Metrics can be filtered based on the metric name and the metric dimensions (min, max, percentiles, etc).
 
 ## Supported Kafka versions
-
+- For Kafka `0.9.0.0` or later use `kafka-statsd-metrics2-0.5.0`
 - For Kafka `0.8.2.0` or later use `kafka-statsd-metrics2-0.4.0`
 - For Kafka `0.8.1.1` or prior use `kafka-statsd-metrics2-0.3.0`
 
 
 ## Releases
- 
+### 0.5.0
+
+ - `0.5.0` adds support for new producer/consumer in kafka 0.9.0
+ - [New producer metrics](http://kafka.apache.org/documentation.html#new_producer_monitoring) are introduced in kafka 0.9.0
+
+
 ### 0.4.0
 
  - `0.4.0` adds support for tags on metrics. See [dogstatsd extensions](http://docs.datadoghq.com/guides/dogstatsd/#tags). If your statsd server does not support tags, you can disable them in the Kafka configuration. See property `external.kafka.statsd.tag.enabled` below.
@@ -38,14 +43,17 @@ Metrics can be filtered based on the metric name and the metric dimensions (min,
 ## How to install?
 
 - [Download](https://bintray.com/airbnb/jars/kafka-statsd-metrics2/view) or build the shadow jar for `kafka-statsd-metrics`.
-- Install the jar in Kafka classpath, typically `./kafka_2.9.2-0.8.2.1/libs/`
+- Install the jar in Kafka classpath, typically `./kafka_2.9.2-0.9.0.1/libs/`
 - In the Kafka config file, `server.properties`, add the following properties. Default values are in parenthesis.
 
 
 
 ```bash
 
-    # declare the reporter
+    # declare the reporter if new producer/consumer is used
+    metric.reporters=com.airbnb.kafka.StatsdMetricsReporter
+
+    # declare the reporter if old producer/consumer is used
     kafka.metrics.reporters=com.airbnb.kafka.KafkaStatsdMetricsReporter
 
     # enable the reporter, (false)

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'idea'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'com.airbnb'
-description = 'StatsD Support for Kafka Metrics (kafka version: 0.8.1 and 0.8.2)'
+description = 'StatsD Support for Kafka Metrics (kafka version: 0.8 and 0.9)'
 
 repositories {
     mavenCentral()
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     compile 'com.indeed:java-dogstatsd-client:2.0.11'
-    compile 'org.apache.kafka:kafka_2.10:0.8.2.1'
+    compile 'org.apache.kafka:kafka_2.10:0.9.0.1'
     compile 'org.slf4j:slf4j-log4j12:+'
 
     testCompile('junit:junit:4.11',
@@ -54,7 +54,7 @@ shadowJar {
     exclude 'META-INF/*.DSA'
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/maven/*'
-    exclude dependency('org.apache.kafka:kafka_2.10:0.8.2.1')
+    exclude dependency('org.apache.kafka:kafka_2.10:0.9.0.1')
     exclude dependency('org.slf4j:slf4j-log4j12')
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.4.1
+version=0.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.5.0
+version=0.5.0-beta2
 

--- a/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
@@ -40,7 +40,7 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.slf4j.LoggerFactory;
 
 public class NewStatsdMetricsReporter implements MetricsReporter {
-  private static final org.slf4j.Logger log = LoggerFactory.getLogger(StatsDReporter.class);
+  private static final org.slf4j.Logger log = LoggerFactory.getLogger(NewStatsDReporter.class);
 
   static final String STATSD_REPORTER_ENABLED = "external.kafka.statsd.reporter.enabled";
   static final String STATSD_HOST = "external.kafka.statsd.host";

--- a/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
@@ -60,7 +60,7 @@ public class NewStatsdMetricsReporter implements MetricsReporter {
   private MetricsRegistry registry;
   private Map<String, KafkaMetric> kafkaMetrics;
 
-  private boolean isTagEnabled;
+  private Boolean isTagEnabled;
 
   private AbstractPollingReporter underlying = null;
 

--- a/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
@@ -108,8 +108,22 @@ public class NewStatsdMetricsReporter implements MetricsReporter {
 
   @Override
   public void metricRemoval(KafkaMetric metric) {
-    MetricName metricName = new MetricName(null, metric.metricName().group());
-    registry.removeMetric(metricName);
+    // Add new metrics in registry.
+    org.apache.kafka.common.MetricName metricName = metric.metricName();
+    String name = "kafka." + metricName.group() + "." + metricName.name();
+
+    StringBuilder strBuilder = new StringBuilder();
+
+    for (String key : metric.metricName().tags().keySet()) {
+      strBuilder.append(key).append(":").append(metric.metricName().tags().get(key)).append(",");
+    }
+
+    if (strBuilder.length() > 0) {
+      strBuilder.deleteCharAt(strBuilder.length() - 1);
+    }
+
+    MetricName metricNameToRemove = new MetricName(NewStatsdMetricsReporter.class, name, strBuilder.toString());
+    registry.removeMetric(metricNameToRemove);
   }
 
   @Override

--- a/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
@@ -120,15 +120,15 @@ public class NewStatsdMetricsReporter implements MetricsReporter {
   @Override
   public void configure(Map<String, ?> configs) {
     enabled = configs.containsKey(STATSD_REPORTER_ENABLED) ?
-        (Boolean)configs.get(STATSD_REPORTER_ENABLED) : false;
+        Boolean.valueOf((String) configs.get(STATSD_REPORTER_ENABLED)) : false;
     host = configs.containsKey(STATSD_HOST) ?
-        (String) configs.get(STATSD_HOST) : "localhost1";
+        (String) configs.get(STATSD_HOST) : "localhost";
     port = configs.containsKey(STATSD_PORT) ?
-        (Integer) configs.get(STATSD_PORT) : 8125;
+        Integer.parseInt((String) configs.get(STATSD_PORT)) : 8125;
     prefix = configs.containsKey(STATSD_METRICS_PREFIX) ?
         (String) configs.get(STATSD_METRICS_PREFIX) : "";
     pollingPeriodInSeconds = configs.containsKey(POLLING_INTERVAL_SECS) ?
-        (Integer) configs.get(POLLING_INTERVAL_SECS) : 10;
+        Integer.parseInt((String) configs.get(POLLING_INTERVAL_SECS)) : 10;
     metricDimensions = Dimension.fromConfigs(configs, STATSD_DIMENSION_ENABLED);
   }
 

--- a/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/NewStatsdMetricsReporter.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2015.  Airbnb.com
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.airbnb.kafka;
+
+import com.airbnb.metrics.Dimension;
+import com.airbnb.metrics.NewStatsDReporter;
+import com.airbnb.metrics.StatsDReporter;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
+import com.timgroup.statsd.StatsDClientException;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.reporting.AbstractPollingReporter;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.slf4j.LoggerFactory;
+
+public class NewStatsdMetricsReporter implements MetricsReporter {
+  private static final org.slf4j.Logger log = LoggerFactory.getLogger(StatsDReporter.class);
+
+  static final String STATSD_REPORTER_ENABLED = "external.kafka.statsd.reporter.enabled";
+  static final String STATSD_HOST = "external.kafka.statsd.host";
+  static final String STATSD_PORT = "external.kafka.statsd.port";
+  static final String STATSD_METRICS_PREFIX = "external.kafka.statsd.metrics.prefix";
+  static final String POLLING_INTERVAL_SECS = "kafka.metrics.polling.interval.secs";
+  static final String STATSD_DIMENSION_ENABLED = "external.kafka.statsd.dimension.enabled";
+
+  private boolean enabled;
+  private final AtomicBoolean running = new AtomicBoolean(false);
+  private String host;
+  private int port;
+  private String prefix;
+  private long pollingPeriodInSeconds;
+  private EnumSet<Dimension> metricDimensions;
+  private StatsDClient statsd;
+  private MetricsRegistry registry;
+  private Map<String, KafkaMetric> kafkaMetrics;
+
+  private AbstractPollingReporter underlying = null;
+
+  public boolean isRunning() {
+    return running.get();
+  }
+
+  @Override
+  public void init(List<KafkaMetric> metrics) {
+    kafkaMetrics = new HashMap<String, KafkaMetric>();
+
+    if (enabled) {
+      startReporter(10);
+    } else {
+      log.warn("Reporter is disabled");
+    }
+  }
+
+  @Override
+  public void metricChange(final KafkaMetric metric) {
+    // Add new metrics in registry.
+    org.apache.kafka.common.MetricName metricName = metric.metricName();
+    String name = "kafka." + metricName.group() + "." + metricName.name();
+
+    StringBuilder strBuilder = new StringBuilder();
+
+    for (String key : metric.metricName().tags().keySet()) {
+      strBuilder.append(key).append(":").append(metric.metricName().tags().get(key)).append(",");
+    }
+
+    if (strBuilder.length() > 0) {
+      strBuilder.deleteCharAt(strBuilder.length() - 1);
+    }
+
+    if (!kafkaMetrics.containsKey(name)) {
+      Gauge<Double> gauge = new Gauge<Double>() {
+        @Override
+        public Double value() {
+          return metric.value();
+        }
+      };
+
+      registry.newGauge(NewStatsdMetricsReporter.class, name, strBuilder.toString() + "\n", gauge);
+      log.info("          metrics name: {}", name);
+    }
+  }
+
+  @Override
+  public void metricRemoval(KafkaMetric metric) {
+    MetricName metricName = new MetricName(null, metric.metricName().group());
+    registry.removeMetric(metricName);
+  }
+
+  @Override
+  public void close() {
+    stopReporter();
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    enabled = configs.containsKey(STATSD_REPORTER_ENABLED) ?
+        (Boolean)configs.get(STATSD_REPORTER_ENABLED) : false;
+    host = configs.containsKey(STATSD_HOST) ?
+        (String) configs.get(STATSD_HOST) : "localhost1";
+    port = configs.containsKey(STATSD_PORT) ?
+        (Integer) configs.get(STATSD_PORT) : 8125;
+    prefix = configs.containsKey(STATSD_METRICS_PREFIX) ?
+        (String) configs.get(STATSD_METRICS_PREFIX) : "";
+    pollingPeriodInSeconds = configs.containsKey(POLLING_INTERVAL_SECS) ?
+        (Integer) configs.get(POLLING_INTERVAL_SECS) : 10;
+    metricDimensions = Dimension.fromConfigs(configs, STATSD_DIMENSION_ENABLED);
+  }
+
+  public void startReporter(long pollingPeriodInSeconds) {
+    if (pollingPeriodInSeconds <= 0) {
+      throw new IllegalArgumentException("Polling period must be greater than zero");
+    }
+
+    registry = Metrics.defaultRegistry();
+
+    synchronized (running) {
+      if (running.get()) {
+        log.warn("Reporter is already running");
+      } else {
+        statsd = createStatsd();
+        underlying = new NewStatsDReporter(
+            Metrics.defaultRegistry(),
+            statsd,
+            metricDimensions);
+        underlying.start(pollingPeriodInSeconds, TimeUnit.SECONDS);
+        log.info("Started Reporter with host={}, port={}, polling_period_secs={}, prefix={}",
+            host, port, pollingPeriodInSeconds, prefix);
+        running.set(true);
+      }
+    }
+  }
+
+  private StatsDClient createStatsd() {
+    try {
+      return new NonBlockingStatsDClient(prefix, host, port);
+    } catch (StatsDClientException ex) {
+      log.error("Reporter cannot be started");
+      throw ex;
+    }
+  }
+
+  private void stopReporter() {
+    if (!enabled) {
+      log.warn("Reporter is disabled");
+    } else {
+      synchronized (running) {
+        if (running.get()) {
+          underlying.shutdown();
+          statsd.stop();
+          running.set(false);
+          log.info("Stopped Reporter with host={}, port={}", host, port);
+        } else {
+          log.warn("Reporter is not running");
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/airbnb/metrics/Dimension.java
+++ b/src/main/java/com/airbnb/metrics/Dimension.java
@@ -17,6 +17,7 @@
 package com.airbnb.metrics;
 
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -63,4 +64,17 @@ public enum Dimension {    //use name itself as suffix
     return df;
   }
 
+  public static EnumSet<Dimension> fromConfigs(Map<String, ?> configs, String prefix) {
+    EnumSet<Dimension> df = EnumSet.allOf(Dimension.class);
+    for (Dimension k : Dimension.values()) {
+      String key = prefix + k.toString();
+      if (configs.containsKey(key)) {
+        Boolean value = (Boolean) configs.get(key);
+        if (!value) {
+          df.remove(k);
+        }
+      }
+    }
+    return df;
+  }
 }

--- a/src/main/java/com/airbnb/metrics/NewStatsDReporter.java
+++ b/src/main/java/com/airbnb/metrics/NewStatsDReporter.java
@@ -18,9 +18,7 @@ package com.airbnb.metrics;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.EnumSet;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 import com.timgroup.statsd.StatsDClient;
 import com.yammer.metrics.core.Clock;
@@ -187,11 +185,11 @@ public class NewStatsDReporter extends AbstractPollingReporter implements Metric
     statsd.gauge(metricName.getName() + "." + dim.getDisplayName(), value, getTags(metricName));
   }
 
-  private String getTags(MetricName metricName) {
+  private String[] getTags(MetricName metricName) {
     if (this.isTagEnabled) {
-      return metricName.getScope();
+      return new String[]{ metricName.getScope() };
     } else {
-      return "";
+      return new String[] {};
     }
   }
 

--- a/src/main/java/com/airbnb/metrics/NewStatsDReporter.java
+++ b/src/main/java/com/airbnb/metrics/NewStatsDReporter.java
@@ -63,7 +63,7 @@ public class NewStatsDReporter extends AbstractPollingReporter implements Metric
   private final StatsDClient statsd;
   private final Clock clock;
   private final EnumSet<Dimension> dimensions;
-  private final Boolean isTagEnabled;
+  private Boolean isTagEnabled;
 
 
   public NewStatsDReporter(MetricsRegistry metricsRegistry,
@@ -83,6 +83,11 @@ public class NewStatsDReporter extends AbstractPollingReporter implements Metric
     this.dimensions = metricDimensions;
     this.clock = Clock.defaultClock();
     this.isTagEnabled = isTagEnabled;
+
+    if (isTagEnabled) {
+      log.info("Kafka metrics are tagged");
+    }
+
   }
 
   @Override

--- a/src/main/java/com/airbnb/metrics/NewStatsDReporter.java
+++ b/src/main/java/com/airbnb/metrics/NewStatsDReporter.java
@@ -63,22 +63,26 @@ public class NewStatsDReporter extends AbstractPollingReporter implements Metric
   private final StatsDClient statsd;
   private final Clock clock;
   private final EnumSet<Dimension> dimensions;
+  private final Boolean isTagEnabled;
 
 
   public NewStatsDReporter(MetricsRegistry metricsRegistry,
                            StatsDClient statsd,
-                           EnumSet<Dimension> metricDimensions) {
-    this(metricsRegistry, statsd, metricDimensions, REPORTER_NAME);
+                           EnumSet<Dimension> metricDimensions,
+                           Boolean isTagEnabled) {
+    this(metricsRegistry, statsd, metricDimensions, REPORTER_NAME, isTagEnabled);
   }
 
   public NewStatsDReporter(MetricsRegistry metricsRegistry,
                            StatsDClient statsd,
                            EnumSet<Dimension> metricDimensions,
-                           String reporterName) {
+                           String reporterName,
+                           Boolean isTagEnabled) {
     super(metricsRegistry, reporterName);
     this.statsd = statsd;               //exception in statsd is handled by default NO_OP_HANDLER (do nothing)
     this.dimensions = metricDimensions;
     this.clock = Clock.defaultClock();
+    this.isTagEnabled = isTagEnabled;
   }
 
   @Override
@@ -112,7 +116,7 @@ public class NewStatsDReporter extends AbstractPollingReporter implements Metric
 
   @Override
   public void processCounter(MetricName metricName, Counter counter, Long context) throws Exception {
-    statsd.gauge(metricName.getMBeanName(), counter.count(), metricName.getScope());
+    statsd.gauge(metricName.getMBeanName(), counter.count(), getTags(metricName));
   }
 
   @Override
@@ -140,9 +144,9 @@ public class NewStatsDReporter extends AbstractPollingReporter implements Metric
     if (flag == null) {
       log.debug("Gauge can only record long or double metric, it is " + value.getClass());
     } else if (flag.equals(true)) {
-      statsd.gauge(metricName.getName(), new Double(value.toString()), metricName.getScope());
+      statsd.gauge(metricName.getName(), new Double(value.toString()), getTags(metricName));
     } else {
-      statsd.gauge(metricName.getName(), new Long(value.toString()), metricName.getScope());
+      statsd.gauge(metricName.getName(), new Long(value.toString()), getTags(metricName));
     }
   }
 
@@ -175,7 +179,15 @@ public class NewStatsDReporter extends AbstractPollingReporter implements Metric
   }
 
   private void sendDouble(Dimension dim, double value, MetricName metricName) {
-    statsd.gauge(metricName.getName() + "." + dim.getDisplayName(), value, metricName.getScope());
+    statsd.gauge(metricName.getName() + "." + dim.getDisplayName(), value, getTags(metricName));
+  }
+
+  private String getTags(MetricName metricName) {
+    if (this.isTagEnabled) {
+      return metricName.getScope();
+    } else {
+      return "";
+    }
   }
 
   private Boolean isDoubleParsable(final Object o) {

--- a/src/main/java/com/airbnb/metrics/NewStatsDReporter.java
+++ b/src/main/java/com/airbnb/metrics/NewStatsDReporter.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2015.  Airbnb.com
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.airbnb.metrics;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.timgroup.statsd.StatsDClient;
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricProcessor;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Sampling;
+import com.yammer.metrics.core.Summarizable;
+import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.reporting.AbstractPollingReporter;
+import com.yammer.metrics.stats.Snapshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.airbnb.metrics.Dimension.count;
+import static com.airbnb.metrics.Dimension.max;
+import static com.airbnb.metrics.Dimension.mean;
+import static com.airbnb.metrics.Dimension.meanRate;
+import static com.airbnb.metrics.Dimension.median;
+import static com.airbnb.metrics.Dimension.min;
+import static com.airbnb.metrics.Dimension.p75;
+import static com.airbnb.metrics.Dimension.p95;
+import static com.airbnb.metrics.Dimension.p98;
+import static com.airbnb.metrics.Dimension.p99;
+import static com.airbnb.metrics.Dimension.p999;
+import static com.airbnb.metrics.Dimension.rate15m;
+import static com.airbnb.metrics.Dimension.rate1m;
+import static com.airbnb.metrics.Dimension.rate5m;
+import static com.airbnb.metrics.Dimension.stddev;
+
+public class NewStatsDReporter extends AbstractPollingReporter implements MetricProcessor<Long> {
+  static final Logger log = LoggerFactory.getLogger(NewStatsDReporter.class);
+  public static final String REPORTER_NAME = "kafka-statsd-metrics-0.5";
+
+  private final StatsDClient statsd;
+  private final Clock clock;
+  private final EnumSet<Dimension> dimensions;
+
+
+  public NewStatsDReporter(MetricsRegistry metricsRegistry,
+                           StatsDClient statsd,
+                           EnumSet<Dimension> metricDimensions) {
+    this(metricsRegistry, statsd, metricDimensions, REPORTER_NAME);
+  }
+
+  public NewStatsDReporter(MetricsRegistry metricsRegistry,
+                           StatsDClient statsd,
+                           EnumSet<Dimension> metricDimensions,
+                           String reporterName) {
+    super(metricsRegistry, reporterName);
+    this.statsd = statsd;               //exception in statsd is handled by default NO_OP_HANDLER (do nothing)
+    this.dimensions = metricDimensions;
+    this.clock = Clock.defaultClock();
+  }
+
+  @Override
+  public void run() {
+    try {
+      final long epoch = clock.time() / 1000;
+      sendAllKafkaMetrics(epoch);
+    } catch (RuntimeException ex) {
+      log.error("Failed to print metrics to statsd", ex);
+    }
+  }
+
+  private void sendAllKafkaMetrics(long epoch) {
+    final Map<MetricName, Metric> allMetrics = new TreeMap<MetricName, Metric>(getMetricsRegistry().allMetrics());
+    for (Map.Entry<MetricName, Metric> entry : allMetrics.entrySet()) {
+      sendAMetric(entry.getKey(), entry.getValue(), epoch);
+    }
+  }
+
+  private void sendAMetric(MetricName metricName, Metric metric, long epoch) {
+    log.debug("  MBeanName[{}], Group[{}], Name[{}], Scope[{}], Type[{}]",
+        metricName.getName(), metricName.getGroup(), metricName.getName(),
+        metricName.getScope(), metricName.getType());
+
+    try {
+      metric.processWith(this, metricName, epoch);
+    } catch (Exception ignored) {
+      log.error("Error printing regular metrics");
+    }
+  }
+
+  @Override
+  public void processCounter(MetricName metricName, Counter counter, Long context) throws Exception {
+    statsd.gauge(metricName.getMBeanName(), counter.count(), metricName.getScope());
+  }
+
+  @Override
+  public void processMeter(MetricName metricName, Metered meter, Long epoch) {
+    send(meter, metricName);
+  }
+
+  @Override
+  public void processHistogram(MetricName metricName, Histogram histogram, Long context) throws Exception {
+    send((Summarizable) histogram, metricName);
+    send((Sampling) histogram, metricName);
+  }
+
+  @Override
+  public void processTimer(MetricName metricName, Timer timer, Long context) throws Exception {
+    send((Metered) timer, metricName);
+    send((Summarizable) timer, metricName);
+    send((Sampling) timer, metricName);
+  }
+
+  @Override
+  public void processGauge(MetricName metricName, Gauge<?> gauge, Long context) throws Exception {
+    final Object value = gauge.value();
+    final Boolean flag = isDoubleParsable(value);
+    if (flag == null) {
+      log.debug("Gauge can only record long or double metric, it is " + value.getClass());
+    } else if (flag.equals(true)) {
+      statsd.gauge(metricName.getName(), new Double(value.toString()), metricName.getScope());
+    } else {
+      statsd.gauge(metricName.getName(), new Long(value.toString()), metricName.getScope());
+    }
+  }
+
+  protected static final Dimension[] meterDims = {count, meanRate, rate1m, rate5m, rate15m};
+  protected static final Dimension[] summarizableDims = {min, max, mean, stddev};
+  protected static final Dimension[] SamplingDims = {median, p75, p95, p98, p99, p999};
+
+  private void send(Metered metric, MetricName metricName) {
+    double[] values = {metric.count(), metric.meanRate(), metric.oneMinuteRate(),
+        metric.fiveMinuteRate(), metric.fifteenMinuteRate()};
+    for (int i = 0; i < values.length; ++i) {
+      sendDouble(meterDims[i], values[i], metricName);
+    }
+  }
+
+  protected void send(Summarizable metric, MetricName metricName) {
+    double[] values = {metric.min(), metric.max(), metric.mean(), metric.stdDev()};
+    for (int i = 0; i < values.length; ++i) {
+      sendDouble(summarizableDims[i], values[i], metricName);
+    }
+  }
+
+  protected void send(Sampling metric, MetricName metricName) {
+    final Snapshot snapshot = metric.getSnapshot();
+    double[] values = {snapshot.getMedian(), snapshot.get75thPercentile(), snapshot.get95thPercentile(),
+        snapshot.get98thPercentile(), snapshot.get99thPercentile(), snapshot.get999thPercentile()};
+    for (int i = 0; i < values.length; ++i) {
+      sendDouble(SamplingDims[i], values[i], metricName);
+    }
+  }
+
+  private void sendDouble(Dimension dim, double value, MetricName metricName) {
+    statsd.gauge(metricName.getName() + "." + dim.getDisplayName(), value, metricName.getScope());
+  }
+
+  private Boolean isDoubleParsable(final Object o) {
+    if (o instanceof Float) {
+      return true;
+    } else if (o instanceof Double) {
+      return true;
+    } else if (o instanceof Byte) {
+      return false;
+    } else if (o instanceof Short) {
+      return false;
+    } else if (o instanceof Integer) {
+      return false;
+    } else if (o instanceof Long) {
+      return false;
+    } else if (o instanceof BigInteger) {
+      return false;
+    } else if (o instanceof BigDecimal) {
+      return true;
+    }
+    return null;
+  }
+}

--- a/src/test/java/com/airbnb/kafka/KafkaStatsdMetricsReporterTest.java
+++ b/src/test/java/com/airbnb/kafka/KafkaStatsdMetricsReporterTest.java
@@ -59,7 +59,6 @@ public class KafkaStatsdMetricsReporterTest {
     assertTrue("reporter should be running once #init has been invoked", reporter.isRunning());
 
     verify(properties);
-
   }
 
   @Test

--- a/src/test/java/com/airbnb/kafka/NewStatsdMetricsReporterTest.java
+++ b/src/test/java/com/airbnb/kafka/NewStatsdMetricsReporterTest.java
@@ -1,0 +1,51 @@
+package com.airbnb.kafka;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NewStatsdMetricsReporterTest {
+  //@Before
+  //public void
+  private Map<String, Object> configs;
+
+  @Before
+  public void init() {
+    configs = new HashMap<String, Object>();
+    configs.put(NewStatsdMetricsReporter.POLLING_INTERVAL_SECS, Integer.valueOf(11));
+    configs.put(NewStatsdMetricsReporter.STATSD_HOST, "127.0.0.1");
+    configs.put(NewStatsdMetricsReporter.STATSD_PORT, 1234);
+    configs.put(NewStatsdMetricsReporter.STATSD_METRICS_PREFIX, "foo");
+    configs.put(NewStatsdMetricsReporter.STATSD_REPORTER_ENABLED, false);
+  }
+
+  @Test
+  public void init_should_start_reporter_when_enabled() {
+
+    configs.put(NewStatsdMetricsReporter.STATSD_REPORTER_ENABLED, true);
+    NewStatsdMetricsReporter reporter = new NewStatsdMetricsReporter();
+    assertFalse("reporter should not be running", reporter.isRunning());
+    reporter.configure(configs);
+    reporter.init(new ArrayList<KafkaMetric>());
+    assertTrue("reporter should be running once #init has been invoked", reporter.isRunning());
+  }
+
+  @Test
+  public void init_should_not_start_reporter_when_disabled() {
+    configs.put(NewStatsdMetricsReporter.STATSD_REPORTER_ENABLED, false);
+    NewStatsdMetricsReporter reporter = new NewStatsdMetricsReporter();
+    assertFalse("reporter should not be running", reporter.isRunning());
+    reporter.configure(configs);
+    reporter.init(new ArrayList<KafkaMetric>());
+    assertFalse("reporter should NOT be running once #init has been invoked", reporter.isRunning());
+  }
+}


### PR DESCRIPTION
Hello !

Just thought i'd contribute what i've done to stabilize the new backend for Kafka 0.9, as i'm using it targeting production.

This PR includes the following : 
- A fix for the casting error on the boolean reads from config on startup ;
- Addition of the tags toggling, like the old backend (i'm using telegraf as listener and it doesn't support tags for now) ;

if anything seems odd, don't hesitate to comment !
